### PR TITLE
Fix default values for new tasks

### DIFF
--- a/src/main/java/org/yourcompany/yourproject/service/TareaServiceImpl.java
+++ b/src/main/java/org/yourcompany/yourproject/service/TareaServiceImpl.java
@@ -73,6 +73,13 @@ public class TareaServiceImpl implements TareaService {
      */
     @Override
     public Tarea guardar(Tarea tarea) {
+        // Si la tarea es nueva, establecemos valores por defecto para evitar nulos
+        if (tarea.getCompletada() == null) {
+            tarea.setCompletada(false);
+        }
+        if (tarea.getActiva() == null) {
+            tarea.setActiva(true);
+        }
         return tareaRepository.save(tarea);
     }
 


### PR DESCRIPTION
## Summary
- prevent null 'activa' and 'completada' values when saving a new `Tarea`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402dcf5fac832e98eb63cad9a697bd